### PR TITLE
Replace unpinned actions with pinned action

### DIFF
--- a/.github/workflows/build-push-sign.yaml
+++ b/.github/workflows/build-push-sign.yaml
@@ -1,59 +1,48 @@
 name: build-sign-push
-
 on:
   push:
     branches:
       - 'main'
-
 jobs:
   build-image:
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
-
     name: build-image
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           fetch-depth: 1
-
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.4.0
-
+        uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.1.0
-
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
-
+        uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2.5.0
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - id: docker_meta
-        uses: docker/metadata-action@v4.4.0
+        uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e # v4.4.0
         with:
           images: yvyom/the-weakest-link
           tags: type=sha,format=long
-
       - name: Build and Push container images
-        uses: docker/build-push-action@v4.0.0
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
         id: build-and-push
         with:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
-
       - name: Sign the images with GitHub OIDC Token
         env:
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
           TAGS: ${{ steps.docker_meta.outputs.tags }}
-        run: |
+        run: |-
           images=""
           for tag in ${TAGS}; do
             images+="${tag}@${DIGEST} "


### PR DESCRIPTION
<!-- minder: pr-remediation-body: { "ContentSha": "5385ebe30ff94aa199e5d69f05fa7485f5230d11" } -->

This is a Minder automated pull request.

This pull request replaces references to actions by tag to references to actions by SHA.

Verifies that any actions use pinned tags
Pinning an action to a full length commit SHA is currently the only way to use
an action as an immutable release. Pinning to a particular SHA helps mitigate
the risk of a bad actor adding a backdoor to the action's repository, as they
would need to generate a SHA-1 collision for a valid Git object payload.
When selecting a SHA, you should verify it is from the action's repository
and not a repository fork.

For more information, see
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
