### PR TITLE
Replace unpinned actions with pinned action

### DIFF
--- a/.github/workflows/build-push-sign.yaml
+++ b/.github/workflows/build-push-sign.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version: '1.21.x'
       - name: Go build


### PR DESCRIPTION
<!-- minder: pr-remediation-body: { "ContentSha": "317b3f50357412dd6d694274361e91f04c45771c" } -->

This is a Minder automated pull request.

This pull request replaces references to actions by tag to references to actions by SHA.

Verifies that any actions use pinned tags
Pinning an action to a full length commit SHA is currently the only way to use
an action as an immutable release. Pinning to a particular SHA helps mitigate
the risk of a bad actor adding a backdoor to the action's repository, as they
would need to generate a SHA-1 collision for a valid Git object payload.
When selecting a SHA, you should verify it is from the action's repository
and not a repository fork.

For more information, see
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
